### PR TITLE
Exercise 6.5.3のレビューをお願いします

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,7 +1,7 @@
 class User < ActiveRecord::Base
   before_save { email.downcase! }
   validates :name,  presence: true, length: { maximum: 50 }
-  VALID_EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i
+  VALID_EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-]+(?:\.[a-z\d\-]+)*\.[a-z]+\z/i
   validates :email, presence: true, format: { with: VALID_EMAIL_REGEX },
                     uniqueness: { case_sensitive: false }
   has_secure_password

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -36,7 +36,7 @@ describe User do
   describe "when email format is invalid" do
     it "should be invalid" do
       addresses = %w[user@foo,com user_at_foo.org example.user@foo.
-                     foo@bar_baz.com foo@bar+baz.com]
+                     foo@bar_baz.com foo@bar+baz.com foo@bar..com]
       addresses.each do |invalid_address|
         @user.email = invalid_address
         expect(@user).not_to be_valid


### PR DESCRIPTION
@tacahilo @kitak @gs3 @keokent
今回も @yutokyokutyo とのペアプロで進めました。
ユーザー登録でのメールアドレスの正規表現の不備を修正しました。
具体的には「foo@bar..com」というドットの重複を許可しませんが、「foo@bar.baz.com」という表記はOKという正規表現になっています。
レビューをお願いいたします！
### やること
- [x] user_spec の無効なメールアドレスに「foo@bar..com」追加して、redになることを確認する  
  ※ 「when email format is invalid」のテストは、[Listing 6.13](http://www.railstutorial.org/book/modeling_users#code-email_format_validation_tests) で追加。

![2014-08-01 17 56 01](https://cloud.githubusercontent.com/assets/1731974/3776956/0a4eac54-195c-11e4-94c2-16ebf813c448.png)
- [x] ユーザーモデルの正規表現を修正する  
  ※ before_saveは、[Listing 6.32](http://www.railstutorial.org/book/modeling_users#code-better_email_regex) を参考にしました。
### 実行結果

```
% bundle exec rspec spec/
...................................

Finished in 0.39392 seconds
35 examples, 0 failures
```

演習URL：http://www.railstutorial.org/book/modeling_users#sec-modeling_users_exercises
