### PR TITLE
Exercise 7.6.2にてエラーメッセージの表示テストを追加する

### DIFF
--- a/spec/requests/user_pages_spec.rb
+++ b/spec/requests/user_pages_spec.rb
@@ -29,6 +29,13 @@ describe "User pages" do
       it "should not create a user" do
         expect { click_button submit }.not_to change(User, :count)
       end
+
+      describe "after submission" do
+        before { click_button submit }
+
+        it { should have_title('Sign up') }
+        it { should have_content('error') }
+      end
     end
 
     describe "with valid information" do


### PR DESCRIPTION
@tacahilo @kitak @gs3 @keokent

@yutokyokutyo とのペアプロで進めました。
Sing Upページのフォームから不正なデータを送信すると、
エラーメッセージが正しく表示されるかどうかのテストを追加しました。
レビューをお願いいたします！
### やること
- [x] 不正な値を送信した後のページで、タイトルに「Sign up」本文に「error」が含まれているかをチェックするテスト (after submission) を追加する  
  ※ [Listing 7.31](http://www.railstutorial.org/book/sign_up#code-error_messages_test) を参考にしました。
### 実行結果
- [x] 「after submission」テストのグリーンを確認する

```
% bundle exec rspec spec/requests/user_pages_spec.rb -e "after submission"
Run options: include {:full_description=>/after\ submission/}
..

Finished in 0.20109 seconds
2 examples, 0 failures
```
- [x] 全体テストのグリーンを確認する

```
% bundle exec rspec spec/
.........................................

Finished in 0.96906 seconds
41 examples, 0 failures
```

演習URL：http://www.railstutorial.org/book/sign_up#sec-signup_exercises
