### PR TITLE
[Exercises 7.6.4] テンプレートをcontent_tagを使用した簡潔なコードに修正する

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -12,7 +12,7 @@
     <%= render 'layouts/header' %>
     <div class="container">
       <% flash.each do |key, value| %>
-        <div class="alert alert-<%= key %>"><%= value %></div>
+        <%= content_tag(:div, value, class: "alert alert-#{key}") %>
       <% end %>
       <%= yield %>
       <%= render 'layouts/footer' %>


### PR DESCRIPTION
@tacahilo @kitak @gs3 @keokent

`content_tag` を使用して、HTMLとERBが混在したテンプレートを簡潔なコードに修正しました。
レビューをお願いいたします！
（@yutokyokutyo とのペアプロで進めました）
### やること
- [x] `content_tag` を使用して、flash変数の処理を修正する  
  ※ [Listing 7.33](http://www.railstutorial.org/book/sign_up#code-layout_flash_content_tag) を参考にしました。  
  ※ [Listing 7.27](http://www.railstutorial.org/book/sign_up#code-layout_flash) ：HTMLとERBが混在した修正前のコードです。
### 実行結果
- [x] 全体テストのグリーンを確認する

```
% bundle exec rspec spec/
.......................................

Finished in 0.70298 seconds
39 examples, 0 failures
```

演習URL：http://www.railstutorial.org/book/sign_up#sec-signup_exercises
