### PR TITLE
[Exercises 8.5.2] utilitiesにメソッドを加えて、ユーザーと認証スペックをリファクタリングする

### DIFF
--- a/spec/requests/authentication_pages_spec.rb
+++ b/spec/requests/authentication_pages_spec.rb
@@ -19,21 +19,17 @@ describe "Authentication" do
       before { click_button "Sign in" }
 
       it { should have_title('Sign in') }
-      it { should have_selector('div.alert.alert-error') }
+      it { should have_error_message }
 
       describe "after visiting another page" do
         before { click_link "Home" }
-        it { should_not have_selector('div.alert.alert-error') }
+        it { should_not have_error_message }
       end
     end
 
     describe "with valid information" do
       let(:user) { FactoryGirl.create(:user) }
-      before do
-        fill_in "Email",    with: user.email.upcase
-        fill_in "Password", with: user.password
-        click_button "Sign in"
-      end
+      before { valid_signin(user) }
 
       it { should have_title(user.name) }
       it { should have_link('Profile',     href: user_path(user)) }

--- a/spec/requests/user_pages_spec.rb
+++ b/spec/requests/user_pages_spec.rb
@@ -39,12 +39,7 @@ describe "User pages" do
     end
 
     describe "with valid information" do
-      before do
-        fill_in "Name",         with: "Example User"
-        fill_in "Email",        with: "user@example.com"
-        fill_in "Password",     with: "foobar"
-        fill_in "Confirmation", with: "foobar"
-      end
+      before { valid_signup }
 
       describe "after saving the user" do
         before { click_button submit }
@@ -52,7 +47,7 @@ describe "User pages" do
 
         it { should have_link('Sign out') }
         it { should have_title(user.name) }
-        it { should have_selector('div.alert.alert-success', text: 'Welcome') }
+        it { should have_success_message('Welcome') }
       end
 
       it "should create a user" do

--- a/spec/support/utilities.rb
+++ b/spec/support/utilities.rb
@@ -6,8 +6,21 @@ def valid_signin(user)
   click_button "Sign in"
 end
 
+def valid_signup
+  fill_in "Name",         with: "Example User"
+  fill_in "Email",        with: "user@example.com"
+  fill_in "Password",     with: "foobar"
+  fill_in "Confirmation", with: "foobar"
+end
+
 RSpec::Matchers.define :have_error_message do |message|
   match do |page|
     expect(page).to have_selector('div.alert.alert-error', text: message)
+  end
+end
+
+RSpec::Matchers.define :have_success_message do |message|
+  match do |page|
+    expect(page).to have_selector('div.alert.alert-success', text: message)
   end
 end


### PR DESCRIPTION
@tacahilo @kitak @gs3 @keokent
### Exercises 8.5.2

utilitiesにメソッドを加えて、ユーザーと認証スペックにおけるテストと実装を分離しました。
レビューをお願いいたします！
### やること
- [x] utilitiesにヘルパー「valid_signup」とマッチャ「have_success_message」を追加する
  ※ [Listing 8.34](http://www.railstutorial.org/book/sign_in_out#code-have_error_message) にて、ヘルパー「valid_signin」とマッチャ「have_error_message」は追加済み。
- [x] 上記で定義したメソッドを、認証スペックで利用する (3ヶ所)
- [x] 同様にユーザースペックを修正する (2ヶ所)
### 実行結果
- [x] 全体テストでグリーンを確認

```
% bundle exec rspec spec/
........................................................
Finished in 1.8 seconds
56 examples, 0 failures
```

演習URL：http://www.railstutorial.org/book/sign_in_out#sec-sign_in_out_exercises
