### PR TITLE
UPDATEメソッドにPATCHリクエストを直接発行するテストを追加する

### DIFF
--- a/spec/requests/user_pages_spec.rb
+++ b/spec/requests/user_pages_spec.rb
@@ -140,5 +140,17 @@ describe "User pages" do
       specify { expect(user.reload.name).to  eq new_name }
       specify { expect(user.reload.email).to eq new_email }
     end 
+
+    describe "forbidden attributes" do
+      let(:params) do
+        { user: { admin: true, password: user.password,
+                  password_confirmation: user.password } }
+      end
+      before do
+        sign_in user, no_capybara: true
+        patch user_path(user), params
+      end
+      specify { expect(user.reload).not_to be_admin }
+    end
   end
 end


### PR DESCRIPTION
@tacahilo @kitak @gs3 @keokent

user_params (strong parameters) が正常に機能して、adminが編集不可であることを確かめるテストを追加しました。
テストを追加した後に、敢えてadmin属性の更新を許可することで、テストに失敗することも確認しました。
レビューのほどよろしくお願いいたします。
### 修正箇所
- [x] 不正なPATCHリクエストを送信するテストを追加する  
  ※ [Listing 9.48](https://www.railstutorial.org/book/updating_and_deleting_users#code-forbidden_admin_test) を参考にしました。
### テストが機能しているか確認する
- [x] user_params にadmin属性の編集を許可する

```
def user_params
  params.require(:user).permit(:name, :email, :password,
                               :password_confirmation, :admin)
end
```
- [x] 全体テストが失敗することを確認

```
% bundle exec Rspec spec/            
......................................................................................F

Failures:

  1) User pages edit forbidden attributes
     Failure/Error: specify { expect(user.reload).not_to be_admin }
       expected admin? to return false, got true
     # ./spec/requests/user_pages_spec.rb:153:in `block (4 levels) in <top (required)>'

Finished in 4.83 seconds
87 examples, 1 failure

Failed examples:

rspec ./spec/requests/user_pages_spec.rb:153 # User pages edit forbidden attributes
```
### 実行結果
- [x] 再び、user_params にてadmin属性の編集を許可しないようにする
- [x] 全体テストでグリーンを確認

```
% bundle exec Rspec spec/
.......................................................................................

Finished in 5.16 seconds
87 examples, 0 failures
```

演習URL：http://www.railstutorial.org/book/updating_and_deleting_users#sec-updating_deleting_exercises
