### PR TITLE
[Exercises 9.6.2] Gravatarの画像変更リンクを別タブでオープンするように指定する

### DIFF
--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -22,6 +22,6 @@
     <% end %>
 
     <%= gravatar_for @user %>
-    <a href="http://gravatar.com/emails">change</a>
+    <a href="http://gravatar.com/emails" target="_blank">change</a>
   </div>
 </div>


### PR DESCRIPTION
### Exercises 9.6.2

@tacahilo @kitak @gs3 @keokent

Gravatarの画像変更リンクのみ、別タブ (ブラウザによっては別ウィンドウ)でオープンするようにしました。
具体的にはターゲットに「_blank」を指定しています。レビューのほどよろしくお願いします！
### 修正箇所
- [x] Gravatarの画像変更リンクのHTMLタグに「target="_blank"」を追加しました
### テスト結果
- [x] テストは用意していないのですが、手元でタブが開くことを確認しました
  ![528cd2450debf1d32ea8a77e343b6319](https://cloud.githubusercontent.com/assets/1731974/4146752/183bcddc-3410-11e4-94bd-854d15c72e53.png)

演習URL：http://www.railstutorial.org/book/updating_and_deleting_users#sec-updating_deleting_exercises
