### PR TITLE
[Exercises 9.6.3] 未ログイン時に、ProfileとSettingsのリンクが表示されていないことをテストする

### DIFF
--- a/spec/requests/authentication_pages_spec.rb
+++ b/spec/requests/authentication_pages_spec.rb
@@ -9,6 +9,8 @@ describe "Authentication" do
 
     it { should have_content('Sign in') }
     it { should have_title('Sign in') }
+    it { should_not have_link('Profile') }
+    it { should_not have_link('Settings') }
   end
 
   describe "signin" do
@@ -20,6 +22,8 @@ describe "Authentication" do
 
       it { should have_title('Sign in') }
       it { should have_error_message }
+      it { should_not have_link('Profile') }
+      it { should_not have_link('Settings') }
 
       describe "after visiting another page" do
         before { click_link "Home" }


### PR DESCRIPTION
### Exercises 9.6.3

@tacahilo @kitak @gs3 @keokent

未ログイン時に、表示されるべきでないリンクが現れていないかどうかをテストしました。
具体的には、authentication_pages_specに4つのテストを追加し、
　1. サインインページにアクセスした時
　2. サインインに失敗した時
に~~「Setting」と「Sign in」~~「Profile」と「Settings」リンクが正しく表示されていないことを確認しています。
レビューのほどよろしくお願いします！
### 修正箇所
- [x] Specファイルに下記を追加して、リンクテキストが表示されていないことをテストする

```
it { should_not have_link('Profile') }
it { should_not have_link('Settings') }
```
### テスト結果
- [x] 全体テストでグリーンを確認

```
% bundle exec Rspec spec/
..........................................................................................

Finished in 5.14 seconds
90 examples, 0 failures
```

演習URL：http://www.railstutorial.org/book/updating_and_deleting_users#sec-updating_deleting_exercises
