### PR TITLE
[Exercises 9.6.6] サインインユーザーが不要なアクションを実行したときルートURLにリダイレクトする

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,8 +1,8 @@
 class UsersController < ApplicationController
-  before_action :signed_in_user,   only: [:index, :edit, :update, :destroy]
-  before_action :correct_user,     only: [:edit, :update]
-  before_action :admin_user,       only: :destroy
-  before_action :redirect_to_root, only: [:new, :create]
+  before_action :signed_in_user,              only: [:index, :edit, :update, :destroy]
+  before_action :correct_user,                only: [:edit, :update]
+  before_action :admin_user,                  only: :destroy
+  before_action :redirect_for_signed_in_user, only: [:new, :create]
 
   def index
     @users = User.paginate(page: params[:page])
@@ -68,7 +68,7 @@ class UsersController < ApplicationController
       redirect_to(root_url) unless current_user.admin?
     end
 
-    def redirect_to_root
+    def redirect_for_signed_in_user
       redirect_to root_url if signed_in?
     end
 end


### PR DESCRIPTION
### Exercises 9.6.6

@tacahilo @kitak @gs3 @keokent

サインインユーザーが不要なアクション (new,create) を実行すると、ルートURLへリダイレクトされるようにユーザーコントローラを修正しました。
before_filterに「redirected_user」というメソッドを追加して実装しています。
レビューのほどよろしくお願いします！
### 修正箇所
- [x] サインインしている場合はルートURLへリダイレクトされるメソッド(redirected_user) を追加
- [x] before_filterを使用して、追加したメソッドがnew,createアクションの前に実行されるようにする
### テスト結果
- [x] 全体テストでグリーンを確認

```
% bundle exec Rspec spec/
...........................................................................................
Finished in 5.34 seconds
91 examples, 0 failures
```
### 備考

正しくリダイレクトされていることを確認するために、目視での確認も行いました
- Flashを利用したコードに修正

``` ruby
def redirected_user
  redirect_to root_url, notice: "debug" if signed_in?
end
```
- サインインユーザーで「http://localhost:3000/users/new」にアクセスすると、ルートURLにリダイレクトされFlashメッセージが表示される

![2014-09-08 11 52 23](https://cloud.githubusercontent.com/assets/1731974/4181544/36625844-371c-11e4-972e-3f21782dd84e.png)

演習URL：http://www.railstutorial.org/book/updating_and_deleting_users#sec-updating_deleting_exercises
