### PR TITLE
[Exercises 10.5.2] homeとprofileページのページネーション表示をテストする

### DIFF
--- a/spec/requests/micropost_pages_spec.rb
+++ b/spec/requests/micropost_pages_spec.rb
@@ -54,16 +54,20 @@ describe "Micropost pages" do
     let(:default_per_page){ 30 }
 
     context "should not view by 30 microposts" do
-      let!(:u30) { FactoryGirl.create_list(:micropost, default_per_page, user: user) }
-      before { visit user_path(user) }
+      before do
+        FactoryGirl.create_list(:micropost, default_per_page, user: user)
+        visit user_path(user)
+      end
 
       it { should have_selector('ol.microposts li', count: 30) }
       it { should_not have_selector('div.pagination') }
     end
 
     context "should view by 31 microposts" do
-      let!(:u31) { FactoryGirl.create_list(:micropost, default_per_page + 1, user: user) }
-      before { visit user_path(user) }
+      before do
+        FactoryGirl.create_list(:micropost, default_per_page + 1, user: user)
+        visit user_path(user)
+      end
 
       it { should have_selector('ol.microposts li', count: 30) }
       it { should have_selector('div.pagination') }

--- a/spec/requests/user_pages_spec.rb
+++ b/spec/requests/user_pages_spec.rb
@@ -90,16 +90,20 @@ describe "User pages" do
       let(:default_per_page){ 30 }
 
       context "should not view by 30 microposts" do
-        let!(:u30) { FactoryGirl.create_list(:micropost, default_per_page, user: user) }
-        before { visit user_path(user) }
+        before do
+          FactoryGirl.create_list(:micropost, default_per_page, user: user)
+          visit user_path(user)
+        end
 
         it { should have_selector('ol.microposts li', count: 30) }
         it { should_not have_selector('div.pagination') }
       end
 
       context "should view by 31 microposts" do
-        let!(:u31) { FactoryGirl.create_list(:micropost, default_per_page + 1, user: user) }
-        before { visit user_path(user) }
+        before do
+          FactoryGirl.create_list(:micropost, default_per_page + 1, user: user)
+          visit user_path(user)
+        end
 
         it { should have_selector('ol.microposts li', count: 30) }
         it { should have_selector('div.pagination') }


### PR DESCRIPTION
## Exercises 10.5.2

@tacahilo @kitak @gs3 @keokent

homeとprofileページのマイクロポストフィードに、ページネーションが表示されているかを
確認するテストを作成しました。
1ページにつき30のマイクロポストが表示される仕様になっているので、
ページネーションを出現させるために、FactoryGirlでマイクロポストがちょうど31になるようにしています。（profileページのテストはlet!内で2つ作成済みなので29のみ追加しました）

レビューのほどよろしくお願いします！
### 行ったこと
- [x] homeページのフィードにページネーションが表示されていることをテストする (micropost_pages_spec.rb)
- [x] 同様にprofileページでもテストをする (user_pages_spec.rb)

演習URL：https://www.railstutorial.org/book/user_microposts#sec-micropost_exercises
