### PR TITLE
[Exercises 11.5.1] ユーザーが削除されると関連するrelationshipsまたはreverse_relationshipsも一緒に削除さていることをテストする

### DIFF
--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -209,18 +209,22 @@ describe User do
       follower.follow!(@user)
     end
 
-    it "should destroy associated relationship" do
-      relationships = @user.relationships
-      relationships.should_not be_empty
-      @user.destroy
-      relationships.should be_empty
+    context 'relationship' do
+      it "should be destroyed with associated users" do
+        relationships = @user.relationships
+        relationships.should_not be_empty
+        @user.destroy
+        relationships.should be_empty
+      end
     end
 
-    it "should destroy associated reverse relationship" do
-      reverse_relationships = @user.reverse_relationships
-      reverse_relationships.should_not be_empty
-      @user.destroy
-      reverse_relationships.should be_empty
+    context 'reverse relationship' do
+      it "should be destroyed with associated users" do
+        reverse_relationships = @user.reverse_relationships
+        reverse_relationships.should_not be_empty
+        @user.destroy
+        reverse_relationships.should be_empty
+      end
     end
   end
 end


### PR DESCRIPTION
### Exercises 11.5.1

@tacahilo @kitak @gs3 @keokent

ユーザーモデルで定義したrelationshipsモデルとのdestroy関係のテストを追加しました。
(dependent: :destroy)
テストでは、あるユーザーを削除するとユーザーに紐づいたrelationships(reverse_relationships)も一緒に削除されることを確認しています。

具体的には以下の2パターンです。
1. あるユーザーをフォローしている`@user`を削除すると、relationshipsも一緒に削除される
2. あるユーザーからフォローされている`@user`を削除すると、reverse_relationshipsも一緒に削除される

レビューのほどよろしくお願いします！
### 行ったこと
- [x] ユーザー削除と連動してrelationshipsがdestroyされていることをテストする
- [x] 同様にreverse_relationshipsのテストを追加  
  ※ [Listing 10.12](http://rails-4-0.railstutorial.org/book/user_microposts#code-micropost_dependency_test) 等を参考に作成しました。

演習URL：http://rails-4-0.railstutorial.org/book/following_users#sec-following_exercises
