### PR TITLE
[Exercises 11.5.4] プロフィールページにてフォローとフォロワー数が正しくカウントされているかテストする

### DIFF
--- a/spec/requests/user_pages_spec.rb
+++ b/spec/requests/user_pages_spec.rb
@@ -164,6 +164,48 @@ describe "User pages" do
         end
       end
     end
+
+    describe "following/follower counts" do
+      let(:other_user) { FactoryGirl.create(:user) }
+
+      describe "following counts" do
+        before do
+          user.follow!(other_user)
+          visit user_path(user)
+        end
+
+        it { should have_link("1 following", href: following_user_path(user)) }
+        it { should have_link("0 followers", href: followers_user_path(user)) }
+
+        context "should decrement the followed user count when unfollow" do
+          before do
+            user.unfollow!(other_user)
+            visit user_path(user)
+          end
+
+          it { should have_link("0 following", href: following_user_path(user)) }
+        end
+      end
+
+      describe "followed counts" do
+        before do
+          other_user.follow!(user)
+          visit user_path(user)
+        end
+
+        it { should have_link("0 following", href: following_user_path(user)) }
+        it { should have_link("1 followers", href: followers_user_path(user)) }
+
+        context "should decrement the followers count when unfollow" do
+          before do
+            other_user.unfollow!(user)
+            visit user_path(user)
+          end
+
+          it { should have_link("0 followers", href: followers_user_path(user)) }
+        end
+      end
+    end
   end
 
   describe "signup page" do


### PR DESCRIPTION
### Exercises 11.5.4

@tacahilo @kitak @gs3 @keokent

プロフィールページのサイドバーに表示されている、フォローとフォロワー数のカウントに対するテストを作成しました。

以下の4つをテストしています。
- user がother_user をフォローすると、user の`following`が1増加する
- user がother_user をアンフォローすると、user の`following`が1減少する
- other_user がuser をフォローすると、user の`followers`が1増加する
- other_user がuser をアンフォローすると、user の`followers`が1減少する

レビューのほどよろしくお願いします！
### 行ったこと
- [x] プロフィールページのstats(フォローとフォロワー数を表示する部分) のテストを作成
### テストする部分

![2014-10-24 11 28 26](https://cloud.githubusercontent.com/assets/1731974/4764499/868ec48c-5b26-11e4-98dd-9dce3bf44c6f.png)

演習URL：http://rails-4-0.railstutorial.org/book/following_users#sec-following_exercises
